### PR TITLE
Task/firecrawl batch

### DIFF
--- a/src/gurubase-backend/backend/backend/settings.py
+++ b/src/gurubase-backend/backend/backend/settings.py
@@ -445,5 +445,5 @@ GITHUB_FILE_BATCH_SIZE = config('GITHUB_FILE_BATCH_SIZE', default=100, cast=int)
 CRAWL_INACTIVE_THRESHOLD_SECONDS = config('CRAWL_INACTIVE_THRESHOLD_SECONDS', default=7, cast=int)
 ADMIN_EMAIL = config('ADMIN_EMAIL', default='')
 MAILGUN_API_KEY = config('MAILGUN_API_KEY', default='')
-
+FIRECRAWL_BATCH_SIZE = config('FIRECRAWL_BATCH_SIZE', default=5, cast=int)
 

--- a/src/gurubase-backend/backend/core/data_sources.py
+++ b/src/gurubase-backend/backend/core/data_sources.py
@@ -14,12 +14,12 @@ from core.models import DataSource, DataSourceExists, CrawlState
 from core.gcp import replace_media_root_with_nginx_base_url
 import unicodedata
 from core.github_handler import process_github_repository, extract_repo_name
-from core.requester import get_web_scraper
+from core.requester import FirecrawlScraper, get_web_scraper
 import scrapy
 from scrapy.crawler import CrawlerProcess
 from multiprocessing import Process
 from urllib.parse import urljoin
-from typing import List, Set
+from typing import List, Set, Tuple
 from django.utils import timezone
 
 
@@ -111,6 +111,159 @@ def website_content_extraction(url):
         else:
             logger.error(f"Error extracting content from Website URL {url}. status: {status_code}, reason: {reason}, response: {response}")
             raise WebsiteContentExtractionError(f"Status code: {status_code}\nReason: {reason}")
+
+
+def _validate_scraper_for_batch(scraper) -> None:
+    """Validate that the scraper supports batch processing"""
+    if not isinstance(scraper, FirecrawlScraper):
+        raise ValueError("Batch processing is only supported with FirecrawlScraper")
+
+def _handle_extraction_error(e: Exception) -> None:
+    """Handle content extraction errors and raise appropriate exceptions"""
+    try:
+        status_code = e.response.status_code
+        reason = e.response.reason
+        response = e.response.content
+    except Exception:
+        status_code = 'Unknown'
+        reason = str(e)
+        response = 'Unknown'
+
+    if status_code == 429:
+        logger.warning(f"Throttled for batch Website URLs. status: {status_code}, reason: {reason}, response: {response}")
+        raise WebsiteContentExtractionThrottleError(f"Status code: {status_code}\nReason: {reason}")
+    
+    logger.error(f"Error extracting content from batch Website URLs. status: {status_code}, reason: {reason}, response: {response}")
+    raise WebsiteContentExtractionError(f"Status code: {status_code}\nReason: {reason}")
+
+def website_content_extraction_batch(urls: List[str]) -> List[Tuple[str, str, str, str]]:
+    """
+    Extract content from multiple website URLs in batch using Firecrawl.
+    Returns: List[Tuple[url: str, title: str, content: str, scrape_tool: str]]
+    """
+    try:
+        scraper, scrape_tool = get_web_scraper()
+        _validate_scraper_for_batch(scraper)
+            
+        successful_results, failed_urls = scraper.scrape_urls_batch(urls)
+        
+        # Process and clean successful results
+        processed_results = [
+            (url, clean_title(title), clean_content(content), scrape_tool)
+            for url, title, content in successful_results
+        ]
+            
+        return processed_results
+        
+    except (WebsiteContentExtractionThrottleError, WebsiteContentExtractionError):
+        raise
+    except Exception as e:
+        _handle_extraction_error(e)
+
+
+def _update_data_source_success(data_source, title, content, scrape_tool):
+    """Update data source with successful scrape results"""
+    data_source.title = title
+    data_source.content = content
+    data_source.scrape_tool = scrape_tool
+    data_source.error = ""
+    data_source.user_error = ""
+    data_source.status = DataSource.Status.SUCCESS
+
+def _update_data_source_failure(data_source, error, scrape_tool, is_unsupported=False):
+    """Update data source with failure information"""
+    data_source.scrape_tool = scrape_tool
+    if is_unsupported:
+        data_source.error = error
+        data_source.user_error = "Firecrawl API error"
+    else:
+        data_source.error = "URL was not processed in batch request"
+        data_source.user_error = "Failed to process URL"
+
+    data_source.status = DataSource.Status.FAIL
+
+def _update_data_source_throttled(data_source, error):
+    """Update data source when throttling occurs"""
+    data_source.status = DataSource.Status.NOT_PROCESSED
+    data_source.error = str(error)
+    data_source.user_error = str(error)
+
+def process_website_data_sources_batch(data_sources):
+    """
+    Process multiple website data sources in batch.
+    Returns: List of processed data sources
+    """
+    urls = [ds.url for ds in data_sources]
+    scraper, scrape_tool = get_web_scraper()
+    url_to_data_source = {ds.url: ds for ds in data_sources}
+    
+    def process_urls(urls_to_process):
+        """Process a batch of URLs and return remaining URLs to retry"""
+        try:
+            successful_results, failed_urls = scraper.scrape_urls_batch(urls_to_process)
+        except WebsiteContentExtractionThrottleError as e:
+            # Mark all data sources as NOT_PROCESSED when throttled
+            for url in urls_to_process:
+                _update_data_source_throttled(url_to_data_source[url], e)
+            raise  # Re-raise to stop processing
+        
+        # Handle successful results
+        for url, title, content in successful_results:
+            if url in url_to_data_source:
+                _update_data_source_success(
+                    url_to_data_source[url], 
+                    title, 
+                    content, 
+                    scrape_tool
+                )
+        
+        # Handle failed URLs and collect URLs to retry
+        failed_url_set = {url for url, _ in failed_urls}
+        successful_url_set = {result[0] for result in successful_results}
+        remaining_urls = []
+        
+        for url in urls_to_process:
+            if url in failed_url_set:
+                error = next((error for failed_url, error in failed_urls if failed_url == url), "")
+                _update_data_source_failure(
+                    url_to_data_source[url],
+                    error,
+                    scrape_tool,
+                    is_unsupported="no longer supported" in error
+                )
+                if "no longer supported" not in error:
+                    remaining_urls.append(url)
+            elif url not in successful_url_set:
+                _update_data_source_failure(
+                    url_to_data_source[url],
+                    "URL was not processed",
+                    scrape_tool
+                )
+                remaining_urls.append(url)
+                
+        return remaining_urls
+    
+    try:
+        # First attempt
+        remaining_urls = process_urls(urls)
+        
+        # Retry if needed
+        if remaining_urls:
+            logger.info(f"Retrying batch with {len(remaining_urls)} remaining URLs")
+            remaining_urls = process_urls(remaining_urls)
+            
+            # Mark any remaining URLs as failed
+            for url in remaining_urls:
+                _update_data_source_failure(
+                    url_to_data_source[url],
+                    "Failed after retry",
+                    scrape_tool
+                )
+    except WebsiteContentExtractionThrottleError:
+        # Return data sources without further processing when throttled
+        return list(url_to_data_source.values())
+            
+    return list(url_to_data_source.values())
 
 
 def clean_title(title):

--- a/src/gurubase-backend/backend/core/requester.py
+++ b/src/gurubase-backend/backend/core/requester.py
@@ -140,6 +140,92 @@ class FirecrawlScraper(WebScraper):
 
         return title, scrape_status['markdown']
 
+    def _check_throttling(self, response):
+        """Check if response indicates throttling and raise appropriate exception"""
+        if 'metadata' in response and 'statusCode' in response['metadata']:
+            status_code = response['metadata']['statusCode']
+            if status_code == 429:
+                description = response['metadata'].get('description', '')
+                error_msg = f"Status code: {status_code}. Description: {description}"
+                raise WebsiteContentExtractionThrottleError(error_msg)
+
+    def _process_successful_item(self, item) -> Tuple[str, str, str]:
+        """Process a single successful item from batch response"""
+        url = item.get('metadata', {}).get('sourceURL', '')
+        title = item.get('metadata', {}).get('title', url) or url
+        content = item.get('markdown', '')
+        
+        if not content:
+            raise ValueError("No content found")
+            
+        return url, title, content
+
+    def _extract_failing_indices(self, error_str: str, urls: List[str]) -> List[Tuple[str, str]]:
+        """Extract failing URLs from error message using regex"""
+        import re
+        failed_urls = []
+        
+        try:
+            path_matches = re.finditer(r"'path':\s*(\[[^\]]+\])", error_str)
+            failing_indices = {
+                path_list[1] 
+                for match in path_matches
+                if len(path_list := eval(match.group(1))) > 1 
+                and isinstance(path_list[1], int)
+            }
+            
+            failed_urls = [(urls[i], error_str) for i in failing_indices]
+        except Exception as parse_error:
+            logger.error(f"Error parsing failure response: {parse_error}. Original error: {error_str}")
+            
+        return failed_urls
+
+    def scrape_urls_batch(self, urls: List[str]) -> Tuple[List[Tuple[str, str, str]], List[Tuple[str, str]]]:
+        """
+        Scrape multiple URLs in a batch.
+        Returns: Tuple[
+            List[Tuple[url: str, title: str, content: str]],  # Successful results
+            List[Tuple[url: str, error: str]]  # Failed URLs with their error messages
+        ]
+        """
+        try:
+            batch_scrape_result = self.app.batch_scrape_urls(
+                urls,
+                params={'formats': ['markdown'], 'onlyMainContent': True}
+            )
+
+            # batch_scrape_result = {'metadata': {'statusCode': 429, 'description': 'Rate limit exceeded'}}
+
+            # Check for throttling first
+            self._check_throttling(batch_scrape_result)
+            
+            successful_results = []
+            failed_urls = []
+            
+            # Process successful results
+            for item in batch_scrape_result.get('data', []):
+                try:
+                    result = self._process_successful_item(item)
+                    successful_results.append(result)
+                except ValueError as e:
+                    url = item.get('metadata', {}).get('sourceURL', '')
+                    failed_urls.append((url, str(e)))
+            
+            return successful_results, failed_urls
+            
+        except WebsiteContentExtractionThrottleError:
+            raise
+        except Exception as e:
+            error_str = str(e)
+            if "Bad Request" in error_str and "no longer supported" in error_str:
+                failed_urls = self._extract_failing_indices(error_str, urls)
+                return [], failed_urls or [(url, error_str) for url in urls]
+            elif "429" in error_str:
+                raise WebsiteContentExtractionThrottleError(error_str)
+
+            logger.error(f"Batch scraping failed: {error_str}")
+            return [], [(url, f"Batch scraping failed: {error_str}") for url in urls]
+
 class Crawl4AIScraper(WebScraper):
     """Crawl4AI implementation of WebScraper using AsyncWebCrawler"""
     def __init__(self):

--- a/src/gurubase-backend/backend/core/serializers.py
+++ b/src/gurubase-backend/backend/core/serializers.py
@@ -80,9 +80,13 @@ class DataSourceSerializer(serializers.ModelSerializer):
         if instance.type == DataSource.Type.PDF:
             del repr['url']
 
+        if instance.user_error:
+            repr['error'] = instance.user_error
+
         if instance.type == DataSource.Type.GITHUB_REPO:
             if instance.error:
                 repr['error'] = format_github_repo_error(instance.error, instance.user_error)
+
         return repr
 
 class DataSourceAPISerializer(serializers.ModelSerializer):
@@ -96,9 +100,13 @@ class DataSourceAPISerializer(serializers.ModelSerializer):
         if instance.type == DataSource.Type.PDF:
             del repr['url']
 
+        if instance.user_error:
+            repr['error'] = instance.user_error
+
         if instance.type == DataSource.Type.GITHUB_REPO:
             if instance.error:
                 repr['error'] = format_github_repo_error(instance.error, instance.user_error)
+
         return repr
 
 


### PR DESCRIPTION
Add batch support for firecrawl scraping. Kept crawl4ai sequential. 

- If it encounters throttling, stops the website retrieval for that guru type. Continues for other types of data sources
- If invalid urls are given as argument and an error is returned, retries the valid ones in the batch

Envs:
`FIRECRAWL_BATCH_SIZE = config('FIRECRAWL_BATCH_SIZE', default=5, cast=int)`

Instructions:
None

