### PR TITLE
Remove unused message for no guru access in MyGurus component

### DIFF
--- a/src/gurubase-frontend/src/components/MyGurus/index.js
+++ b/src/gurubase-frontend/src/components/MyGurus/index.js
@@ -56,18 +56,6 @@ export const MyGurusClient = () => {
         <div className="flex flex-col items-center justify-center w-full max-w-4xl mx-auto px-4 h-[100vh]">
           <LoaderCircle className="h-8 w-8 animate-spin text-gray-400" />
         </div>
-      ) : myGurus?.length === 0 && !isSelfHosted ? (
-        <div className="text-gray-500 text-center flex flex-col items-center justify-center w-full max-w-4xl mx-auto px-4 h-[100vh]">
-          You haven&apos;t been granted access to any gurus yet. Please check
-          out the{" "}
-          <a
-            href="https://github.com/Gurubase/gurubase?tab=readme-ov-file#how-to-claim-a-guru"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-500 hover:underline">
-            How to Claim a Guru
-          </a>
-        </div>
       ) : (
         <GuruList allGuruTypes={myGurus} title="My Gurus" />
       )}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
- Remove the info message when a user in cloud does not manage any gurus. Show the guru creation UI that takes the user to guru creation form instead.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- On cloud, entered the `my_gurus/` page with a non-admin user that does not maintain any gurus. Went through the "New Guru" button and visited the guru creation form.
- On selfhosted, tested that the UI is the same as before.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
<img width="1512" alt="Screenshot 2025-03-27 at 14 06 39" src="https://github.com/user-attachments/assets/7c868985-88dc-4585-923a-fae158a74673" />

## Checklist
<!-- Please check all that apply using "x". -->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation and updated the README.md
- [x] I have tested my changes in different environments (Cloud and Self-hosted)

## Related Issues (If applicable)
<!-- Add the issue number here if applicable -->

## Manual Actions on Deployment (If applicable)

### Cloud
<!-- Add any manual actions that need to be taken on deployment -->

### Self-hosted
<!-- Add any manual actions that need to be taken on deployment -->

## Additional Notes
<!-- Add any additional notes or context about the PR here --> 