### PR TITLE
Task/website scrape improvement

### DIFF
--- a/.dev/local-dev-docker-compose.yml
+++ b/.dev/local-dev-docker-compose.yml
@@ -29,6 +29,8 @@ services:
       POSTGRES_USER: postgres
     volumes:
       - ./.devdata/local/postgres:/var/lib/postgresql/data
+    ports:
+      - 5434:5432
     restart: always
 
   redis:
@@ -36,7 +38,17 @@ services:
     container_name: local-dev-gurubase-redis
     volumes:
       - ./.devdata/local/redis:/data
+    ports:
+      - 6380:6379
     restart: always
+
+  attu:
+    image: zilliz/attu:latest
+    container_name: local-dev-gurubase-attu
+    ports:
+      - 8000:3000
+    restart: always
+    
 
 networks:
   default:

--- a/.dev/selfhosted-dev-docker-compose.yml
+++ b/.dev/selfhosted-dev-docker-compose.yml
@@ -29,6 +29,8 @@ services:
       POSTGRES_USER: postgres
     volumes:
       - ./.devdata/selfhosted/postgres:/var/lib/postgresql/data
+    ports:
+      - 5435:5432
     restart: always
 
   redis:
@@ -36,6 +38,8 @@ services:
     container_name: selfhosted-dev-gurubase-redis
     volumes:
       - ./.devdata/selfhosted/redis:/data
+    ports:
+      - 6381:6379
     restart: always
 
   nginx:
@@ -46,6 +50,13 @@ services:
       - ./.devdata/selfhosted/backend_media:/django_media_files
     ports:
       - "8019:8019"
+    restart: always
+
+  attu:
+    image: zilliz/attu:latest
+    container_name: local-dev-gurubase-attu
+    ports:
+      - 8001:3000
     restart: always
 
 networks:

--- a/src/gurubase-backend/backend/core/admin.py
+++ b/src/gurubase-backend/backend/core/admin.py
@@ -204,7 +204,7 @@ class DataSourceAdmin(admin.ModelAdmin):
     list_filter = ('type', 'status', 'in_milvus', 'content_rewritten', 'initial_summarizations_created', 'final_summarization_created', 'guru_type__slug', 'reindex_count', 'private')
     search_fields = ['id', 'title', 'guru_type__slug', 'type', 'url']
     ordering = ('-id',)
-    actions = ['write_to_milvus', 'delete_from_milvus', 'change_status_to_not_processed', 'reset_initial_summarizations_created', 'reset_final_summarization_created']
+    actions = ['write_to_milvus', 'delete_from_milvus', 'change_status_to_not_processed', 'reset_initial_summarizations_created', 'reset_final_summarization_created', 'scrape_main_content']
 
     def write_to_milvus(self, request, queryset):
         for obj in queryset:
@@ -234,6 +234,12 @@ class DataSourceAdmin(admin.ModelAdmin):
     def reset_final_summarization_created(self, request, queryset):
         queryset.update(final_summarization_created=False)
     reset_final_summarization_created.short_description = "Reset final summarization created"
+
+    def scrape_main_content(self, request, queryset):
+        from core.tasks import scrape_main_content
+        data_source_ids = list(queryset.values_list('id', flat=True))
+        scrape_main_content.delay(data_source_ids)
+    scrape_main_content.short_description = "Scrape main content"
 
 
 @admin.register(Favicon)

--- a/src/gurubase-backend/backend/core/models.py
+++ b/src/gurubase-backend/backend/core/models.py
@@ -1,4 +1,5 @@
 import secrets
+from django.db import transaction
 import traceback
 import logging
 import os
@@ -945,6 +946,58 @@ class DataSource(models.Model):
             GithubFile.objects.filter(data_source=self).update(in_milvus=False, doc_ids=[])
 
         self.save()
+
+    def scrape_main_content(self):
+        """
+        Scrape the main content of the data source using Gemini to extract the main content from HTML.
+        Updates Milvus immediately after processing.
+        Skips if the content has already been rewritten or is not in a success status.
+        """
+        from core.requester import GeminiRequester
+        gemini_requester = GeminiRequester(model_name=settings.LARGE_GEMINI_MODEL)
+
+        try:
+            # Skip if already rewritten or not in success status
+            if self.content_rewritten or self.status != DataSource.Status.SUCCESS:
+                logger.info(f"Skipping data source {self.id} - already rewritten or not in success status")
+                return
+                
+            if not self.content:
+                logger.warning(f"Data source {self.id} has no content to process")
+                return
+                
+            # Store original content if not already stored
+            if not self.original_content:
+                self.original_content = self.content
+            
+            # Scrape main content using Gemini
+            main_content = gemini_requester.scrape_main_content(self.content)
+            
+            # Update data source with new content
+            self.content = main_content
+            self.content_rewritten = True
+
+            with transaction.atomic():
+                # Save to database
+                self.save()
+                
+                # Delete from Milvus
+                try:
+                    self.delete_from_milvus()
+                except Exception as e:
+                    logger.error(f"Error deleting data source {self.id} from Milvus: {str(e)}", exc_info=True)
+                
+                # Write to Milvus
+                try:
+                    self.write_to_milvus()
+                except Exception as e:
+                    logger.error(f"Error writing data source {self.id} to Milvus: {str(e)}", exc_info=True)
+            
+        except Exception as e:
+            logger.error(f"Error scraping main content for data source {self.id}: {str(e)}", exc_info=True)
+            self.error = str(e)
+            self.user_error = "Failed to extract main content from the page"
+            self.save()
 
     def create_initial_summarizations(self, max_length=settings.SUMMARIZATION_MAX_LENGTH, chunk_overlap=settings.SUMMARIZATION_OVERLAP_LENGTH):
         """

--- a/src/gurubase-backend/backend/core/models.py
+++ b/src/gurubase-backend/backend/core/models.py
@@ -982,22 +982,14 @@ class DataSource(models.Model):
                 self.save()
                 
                 # Delete from Milvus
-                try:
-                    self.delete_from_milvus()
-                except Exception as e:
-                    logger.error(f"Error deleting data source {self.id} from Milvus: {str(e)}", exc_info=True)
+                self.delete_from_milvus()
                 
                 # Write to Milvus
-                try:
-                    self.write_to_milvus()
-                except Exception as e:
-                    logger.error(f"Error writing data source {self.id} to Milvus: {str(e)}", exc_info=True)
+                self.write_to_milvus()
+
             
         except Exception as e:
             logger.error(f"Error scraping main content for data source {self.id}: {str(e)}", exc_info=True)
-            self.error = str(e)
-            self.user_error = "Failed to extract main content from the page"
-            self.save()
 
     def create_initial_summarizations(self, max_length=settings.SUMMARIZATION_MAX_LENGTH, chunk_overlap=settings.SUMMARIZATION_OVERLAP_LENGTH):
         """

--- a/src/gurubase-backend/backend/core/prompts.py
+++ b/src/gurubase-backend/backend/core/prompts.py
@@ -842,3 +842,11 @@ Context 11 Text:
 # Best way to reverse a string in Python \n def reverse_string(s): return s[::-1] \n print(reverse_string("hello"))
 ```
 </Code context>'''
+
+scrape_main_content_prompt = """
+Extract the website texts in markdown format from that markdown. Get only the main part, remove sidebars, footer, header, etc. Here is the content:
+
+{content}
+
+Do not add any other text or comments. Just return the markdown content. Do not format it like ```markdown, just return the markdown content.
+"""

--- a/src/gurubase-backend/backend/core/requester.py
+++ b/src/gurubase-backend/backend/core/requester.py
@@ -610,6 +610,12 @@ class GeminiRequester():
             HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
         }
 
+    def scrape_main_content(self, content):
+        from .prompts import scrape_main_content_prompt
+        prompt = scrape_main_content_prompt.format(content=content)
+        response = self.client.generate_content(prompt)
+        return response.text
+
     def summarize_text(self, text, guru_type):
         from .prompts import summarize_data_sources_prompt
         from core.utils import get_llm_usage_from_response

--- a/src/gurubase-backend/backend/core/requester.py
+++ b/src/gurubase-backend/backend/core/requester.py
@@ -203,7 +203,7 @@ class FirecrawlScraper(WebScraper):
         try:
             batch_scrape_result = self.app.batch_scrape_urls(
                 urls,
-                params={'formats': ['markdown'], 'onlyMainContent': True, 'timeout': settings.FIRECRAWL_TIMEOUT_MS}
+                params={'formats': ['markdown'], 'onlyMainContent': True, 'timeout': settings.FIRECRAWL_TIMEOUT_MS, 'waitFor': 2000}
             )
 
             # batch_scrape_result = {'metadata': {'statusCode': 429, 'description': 'Rate limit exceeded'}}

--- a/src/gurubase-backend/backend/core/tasks.py
+++ b/src/gurubase-backend/backend/core/tasks.py
@@ -1762,6 +1762,11 @@ def reindex_code_embedding_model(guru_type_id: int, old_model: str, new_model: s
 
 
 @shared_task
+@with_redis_lock(
+    redis_client,
+    'scrape_main_content_lock',
+    1800
+)
 def scrape_main_content(data_source_ids: List[int]):
     """
     Scrape the main content of a list of data sources using Gemini to extract the main content from HTML.


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
- Expose postgres and redis ports and add attu (for milvus) in both selfhosted and cloud for debugging
- Add wait time 2 seconds for firecrawl batch scrape for js to load
- Add admin task to scrape main content of websites and update both the db and milvus

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- Used the admin task and checked the vectors in milvus, and the object in the db.
- Tried to run the task for non-success data sources.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Please check all that apply using "x". -->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation and updated the README.md
- [ ] I have tested my changes in different environments (Cloud and Self-hosted)

## Related Issues (If applicable)
<!-- Add the issue number here if applicable -->

## Manual Actions on Deployment (If applicable)

### Cloud
<!-- Add any manual actions that need to be taken on deployment -->

### Self-hosted
<!-- Add any manual actions that need to be taken on deployment -->

## Additional Notes
<!-- Add any additional notes or context about the PR here --> 