### PR TITLE
View localhost links on selfhosted

### DIFF
--- a/src/gurubase-frontend/src/components/PostContent/index.js
+++ b/src/gurubase-frontend/src/components/PostContent/index.js
@@ -30,7 +30,9 @@ const CustomLink = React.memo(({ node, ...props }) => {
   const isLocalhost =
     href && (href.includes("localhost") || href.includes("127.0.0.1"));
 
-  if (isLocalhost) {
+  const isSelfHosted = process.env.NEXT_PUBLIC_NODE_ENV === "selfhosted";
+
+  if (!isSelfHosted && isLocalhost) {
     return <span {...props} />;
   }
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
- Allow localhost links to be shown as normal links on selfhosted.

## Type of Change
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- Added a reference starting with `http://localhost:8029` to an answer.
- Opened this answer on both cloud and selfhosted. Saw that it is marked blue on selfhosted, and kept unclickable on cloud.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Please check all that apply using "x". -->
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation and updated the README.md
- [x] I have tested my changes in different environments (Cloud and Self-hosted)

## Related Issues (If applicable)
<!-- Add the issue number here if applicable -->

## Manual Actions on Deployment (If applicable)

### Cloud
<!-- Add any manual actions that need to be taken on deployment -->

### Self-hosted
<!-- Add any manual actions that need to be taken on deployment -->

## Additional Notes
<!-- Add any additional notes or context about the PR here --> 